### PR TITLE
Log gift details in order comments

### DIFF
--- a/addgifts/templates/actions/backend/OrderCreate.html
+++ b/addgifts/templates/actions/backend/OrderCreate.html
@@ -2,7 +2,7 @@
 Плагин <a target="_blank" href="?action=products#/addgifts/">Подарки</a>:<br>
 {foreach $to_log as $record}
     {if ($record.vid=='after')}К товарам {else}К товару <b>{$record.product_name|escape}</b> {/if}
-    на основании правил: <b>{implode(', ', $record.rule_names)|escape}</b> добавлены подарки: <br>
+    на основании правил: <b>{implode(', ', $record.rule_names)|escape}</b> в комментарий заказа добавлена информация о подарках:<br>
     {foreach $record.gift_names as $gift_name}
         &nbsp;&nbsp;&nbsp;&nbsp;{$gift_name}<br>
     {/foreach}


### PR DESCRIPTION
## Summary
- add gift descriptions to the order comment instead of inserting additional order items
- update the backend log template to reflect that gift information is written to the comment

## Testing
- php -l lib/classes/traits/shopAddgiftsTraitHelper.class.php

------
https://chatgpt.com/codex/tasks/task_e_68e52526e134832cac0299fe3eb3217a